### PR TITLE
Test proxy

### DIFF
--- a/helm/values/branches.yaml
+++ b/helm/values/branches.yaml
@@ -205,8 +205,8 @@ deployments:
           https_proxy: http://proxy.service:3128
           GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
           GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
-          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0
-          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
+          no_proxy: ".svc.cluster.local,.service,.internal,.vops.int,.googleapis.com,.gcr.io,.gstatic.com,gcr.io,.gcp.cloud.es.io,accounts.google.com,packages.cloud.google.com,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
+          GLOBAL_AGENT_NO_PROXY	: ".svc.cluster.local,.service,.internal,.vops.int,.googleapis.com,.gcr.io,.gstatic.com,gcr.io,.gcp.cloud.es.io,accounts.google.com,packages.cloud.google.com,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
           LAUNCHDARKLY_SDK_KEY: "vault:secret/data/applications/devel#LAUNCHDARKLY_SDK_KEY"
 
 configmaps:

--- a/helm/values/branches.yaml
+++ b/helm/values/branches.yaml
@@ -109,6 +109,12 @@ statefulsets:
         image:  rabbitmq:3.9.11-management-alpine
         imagePullPolicy: IfNotPresent
         extraVars:
+          http_proxy: http://proxy.service:3128
+          https_proxy: http://proxy.service:3128
+          GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
+          GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
+          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io
+          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io"
           RABBITMQ_DEFAULT_VHOST: voice
           RABBITMQ_DEFAULT_USER: voice
           RABBITMQ_DEFAULT_PASS: voice
@@ -132,13 +138,7 @@ deployments:
             name: voice-redis
         image: "redis:5.0.9-alpine"
         imagePullPolicy: IfNotPresent
-        extraVars:
-          http_proxy: http://proxy.service:3128
-          https_proxy: http://proxy.service:3128
-          GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
-          GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
-          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io
-          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io"
+
   voice-eos-hyperion-api:
     replicaCount: 1
     tolerations:
@@ -158,6 +158,12 @@ deployments:
     initContainers:
       check-hyperion-rabbit-mq-health:
         extraVars:
+          http_proxy: http://proxy.service:3128
+          https_proxy: http://proxy.service:3128
+          GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
+          GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
+          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io
+          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,localhost"
           user: voice
           pass: voice
           vhost: voice
@@ -182,7 +188,7 @@ deployments:
           - containerPort: 7000
             protocol: TCP
             name: hyperion-api
-        image: "gcr.io/voice-dev-infra-services/voice/voice-eos-hyperion:{{ .Values.tag }}"
+        image: "gcr.io/voice-dev-infra-services/voice/voice-eos-hyperion:{{ .Values.release.tag }}"
         imagePullPolicy: Always
         command: ["bash", "run.sh","voice-api"]
         lifecycle:
@@ -207,6 +213,12 @@ deployments:
             readOnly: false
         extraVars:
           # LaunchDarkly Config
+          http_proxy: http://proxy.service:3128
+          https_proxy: http://proxy.service:3128
+          GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
+          GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
+          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io
+          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,localhost"
           LAUNCHDARKLY_SDK_KEY: "vault:secret/data/applications/devel#LAUNCHDARKLY_SDK_KEY"
 
 configmaps:
@@ -219,7 +231,7 @@ configmaps:
           pm2_scaling: 1
           node_max_old_space_size: 1024
           chain_name: voice
-          server_addr: 0.0.0.0
+          server_addr: localhost
           server_port: 7000
           server_name: "{{ .Values.config.serverName }}"
           provider_name: "{{ .Values.config.provider_name }}"
@@ -344,7 +356,7 @@ configmaps:
           pm2_scaling: 1
           node_max_old_space_size: 1024
           chain_name: voice
-          server_addr: 0.0.0.0
+          server_addr: localhost
           server_port: 7000
           server_name: "{{ .Values.config.serverName }}"
           provider_name: " {{ .Values.config.provider_name }}"

--- a/helm/values/branches.yaml
+++ b/helm/values/branches.yaml
@@ -8,6 +8,10 @@ config:
   chain_logo_url: "https://storage.googleapis.com/voice_logo/logo.ico"
   es_replicas: 1
   abi_scan: false
+  elastic_host: elastic.service.us-west1-dev.vops.int
+  elastic_user: ""
+  elastic_pass: ""
+
 services:
   voice-eos-hyperion:
     customLabels:
@@ -208,7 +212,10 @@ deployments:
           no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io
           GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,${POD_ID}"
           LAUNCHDARKLY_SDK_KEY: "vault:secret/data/applications/devel#LAUNCHDARKLY_SDK_KEY"
-
+          ELASTIC_USER: "{{ .Values.config.elastic_user }}"
+          ELASTIC_PASS: "{{ .Values.config.elastic_pass }}"
+          ELASTIC_HOST: "{{ .Values.config.elastic_host }}"
+          SERVER_NAME: "{{ .Values.config.server_name }}"
 configmaps:
   eos-hyperion-config-abi:
     toJson: true

--- a/helm/values/branches.yaml
+++ b/helm/values/branches.yaml
@@ -206,7 +206,7 @@ deployments:
           GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
           GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
           no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io
-          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,${POD_ID}"
+          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
           LAUNCHDARKLY_SDK_KEY: "vault:secret/data/applications/devel#LAUNCHDARKLY_SDK_KEY"
 
 configmaps:

--- a/helm/values/branches.yaml
+++ b/helm/values/branches.yaml
@@ -1,17 +1,13 @@
 release:
   tag: latest
 config:
-  serverName: "localhost"
+  serverName: ""
   provider_url: https://voice.com
   provider_name: "voice"
   ## this only take the image form URL
   chain_logo_url: "https://storage.googleapis.com/voice_logo/logo.ico"
   es_replicas: 1
   abi_scan: false
-  elastic_host: elastic.service.us-west1-dev.vops.int
-  elastic_user: '""'
-  elastic_pass: '""'
-
 services:
   voice-eos-hyperion:
     customLabels:
@@ -182,7 +178,7 @@ deployments:
             name: hyperion-api
         image: "gcr.io/voice-dev-infra-services/voice/voice-eos-hyperion:{{ .Values.release.tag }}"
         imagePullPolicy: Always
-        command: ["bash", "scripts/get-secrets.sh","voice-api"]
+        command: ["bash", "run.sh","voice-api"]
         lifecycle:
           preStop:
             exec:
@@ -196,11 +192,11 @@ deployments:
             memory: "256Mi"
         volumeMounts:
           - name: eos-hyperion-connections
-            mountPath: /tmp/connections.json
+            mountPath: hyperion-history-api/connections.json
             subPath: connections.json
             readOnly: false
           - name: "{{ if .Values.config.abi_scan }}eos-hyperion-config-abi{{ else }}eos-hyperion-config{{ end }}"
-            mountPath: /tmp/voice.config.json
+            mountPath: hyperion-history-api/chains/voice.config.json
             subPath: voice.config.json
             readOnly: false
         extraVars:
@@ -212,10 +208,6 @@ deployments:
           no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io
           GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,${POD_ID}"
           LAUNCHDARKLY_SDK_KEY: "vault:secret/data/applications/devel#LAUNCHDARKLY_SDK_KEY"
-          ELASTIC_USER: "{{ .Values.config.elastic_user }}"
-          ELASTIC_PASS: "{{ .Values.config.elastic_pass }}"
-          ELASTIC_HOST: "{{ .Values.config.elastic_host }}"
-          SERVER_NAME: "{{ .Values.config.server_name }}"
 
 configmaps:
   eos-hyperion-config-abi:
@@ -227,7 +219,7 @@ configmaps:
           pm2_scaling: 1
           node_max_old_space_size: 1024
           chain_name: voice
-          server_addr: localhost
+          server_addr: 0.0.0.0
           server_port: 7000
           server_name: "{{ .Values.config.serverName }}"
           provider_name: "{{ .Values.config.provider_name }}"
@@ -352,7 +344,7 @@ configmaps:
           pm2_scaling: 1
           node_max_old_space_size: 1024
           chain_name: voice
-          server_addr: $(POD_IP)
+          server_addr: 0.0.0.0
           server_port: 7000
           server_name: "{{ .Values.config.serverName }}"
           provider_name: " {{ .Values.config.provider_name }}"

--- a/helm/values/branches.yaml
+++ b/helm/values/branches.yaml
@@ -205,7 +205,7 @@ deployments:
           https_proxy: http://proxy.service:3128
           GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
           GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
-          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io
+          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0
           GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
           LAUNCHDARKLY_SDK_KEY: "vault:secret/data/applications/devel#LAUNCHDARKLY_SDK_KEY"
 

--- a/helm/values/branches.yaml
+++ b/helm/values/branches.yaml
@@ -201,12 +201,12 @@ deployments:
             readOnly: false
         extraVars:
           # LaunchDarkly Config
-          http_proxy: http://proxy.service:3128
-          https_proxy: http://proxy.service:3128
-          GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
-          GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
-          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0
-          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
+          http_proxy: vault:secret/data/applications/devel#PROXY
+          https_proxy: vault:secret/data/applications/devel#PROXY
+          GLOBAL_AGENT_HTTP_PROXY: vault:secret/data/applications/devel#PROXY
+          GLOBAL_AGENT_HTTPS_PROXY: vault:secret/data/applications/devel#PROXY
+          no_proxy: "vault:secret/data/applications/devel#NO_PROXY"
+          GLOBAL_AGENT_NO_PROXY	: "vault:secret/data/applications/devel#NO_PROXY"
           LAUNCHDARKLY_SDK_KEY: "vault:secret/data/applications/devel#LAUNCHDARKLY_SDK_KEY"
 
 configmaps:

--- a/helm/values/branches.yaml
+++ b/helm/values/branches.yaml
@@ -9,8 +9,8 @@ config:
   es_replicas: 1
   abi_scan: false
   elastic_host: elastic.service.us-west1-dev.vops.int
-  elastic_user: ""
-  elastic_pass: ""
+  elastic_user: '""'
+  elastic_pass: '""'
 
 services:
   voice-eos-hyperion:

--- a/helm/values/branches.yaml
+++ b/helm/values/branches.yaml
@@ -158,12 +158,6 @@ deployments:
     initContainers:
       check-hyperion-rabbit-mq-health:
         extraVars:
-          http_proxy: http://proxy.service:3128
-          https_proxy: http://proxy.service:3128
-          GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
-          GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
-          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io
-          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,localhost"
           user: voice
           pass: voice
           vhost: voice

--- a/helm/values/branches.yaml
+++ b/helm/values/branches.yaml
@@ -206,7 +206,7 @@ deployments:
           GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
           GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
           no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io
-          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,localhost"
+          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,${POD_ID}"
           LAUNCHDARKLY_SDK_KEY: "vault:secret/data/applications/devel#LAUNCHDARKLY_SDK_KEY"
 
 configmaps:

--- a/helm/values/branches.yaml
+++ b/helm/values/branches.yaml
@@ -1,7 +1,7 @@
 release:
   tag: latest
 config:
-  serverName: ""
+  serverName: "localhost"
   provider_url: https://voice.com
   provider_name: "voice"
   ## this only take the image form URL
@@ -178,7 +178,7 @@ deployments:
             name: hyperion-api
         image: "gcr.io/voice-dev-infra-services/voice/voice-eos-hyperion:{{ .Values.release.tag }}"
         imagePullPolicy: Always
-        command: ["bash", "run.sh","voice-api"]
+        command: ["bash", "scripts/get-secrets.sh","voice-api"]
         lifecycle:
           preStop:
             exec:
@@ -196,7 +196,7 @@ deployments:
             subPath: connections.json
             readOnly: false
           - name: "{{ if .Values.config.abi_scan }}eos-hyperion-config-abi{{ else }}eos-hyperion-config{{ end }}"
-            mountPath: hyperion-history-api/chains/voice.config.json
+            mountPath: /tmp/voice.config.json
             subPath: voice.config.json
             readOnly: false
         extraVars:

--- a/helm/values/branches.yaml
+++ b/helm/values/branches.yaml
@@ -182,7 +182,7 @@ deployments:
             name: hyperion-api
         image: "gcr.io/voice-dev-infra-services/voice/voice-eos-hyperion:{{ .Values.release.tag }}"
         imagePullPolicy: Always
-        command: ["bash", "scripts/get-secrets.sh","voice-api"]
+        command: ["bash", "run.sh","voice-api"]
         lifecycle:
           preStop:
             exec:
@@ -352,7 +352,7 @@ configmaps:
           pm2_scaling: 1
           node_max_old_space_size: 1024
           chain_name: voice
-          server_addr: localhost
+          server_addr: ${POD_IP}
           server_port: 7000
           server_name: "{{ .Values.config.serverName }}"
           provider_name: " {{ .Values.config.provider_name }}"

--- a/helm/values/branches.yaml
+++ b/helm/values/branches.yaml
@@ -109,12 +109,6 @@ statefulsets:
         image:  rabbitmq:3.9.11-management-alpine
         imagePullPolicy: IfNotPresent
         extraVars:
-          http_proxy: http://proxy.service:3128
-          https_proxy: http://proxy.service:3128
-          GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
-          GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
-          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io
-          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io"
           RABBITMQ_DEFAULT_VHOST: voice
           RABBITMQ_DEFAULT_USER: voice
           RABBITMQ_DEFAULT_PASS: voice

--- a/helm/values/branches.yaml
+++ b/helm/values/branches.yaml
@@ -196,7 +196,7 @@ deployments:
             memory: "256Mi"
         volumeMounts:
           - name: eos-hyperion-connections
-            mountPath: hyperion-history-api/connections.json
+            mountPath: /tmp/connections.json
             subPath: connections.json
             readOnly: false
           - name: "{{ if .Values.config.abi_scan }}eos-hyperion-config-abi{{ else }}eos-hyperion-config{{ end }}"
@@ -216,6 +216,7 @@ deployments:
           ELASTIC_PASS: "{{ .Values.config.elastic_pass }}"
           ELASTIC_HOST: "{{ .Values.config.elastic_host }}"
           SERVER_NAME: "{{ .Values.config.server_name }}"
+
 configmaps:
   eos-hyperion-config-abi:
     toJson: true

--- a/helm/values/branches.yaml
+++ b/helm/values/branches.yaml
@@ -201,12 +201,12 @@ deployments:
             readOnly: false
         extraVars:
           # LaunchDarkly Config
-          http_proxy: vault:secret/data/applications/devel#PROXY
-          https_proxy: vault:secret/data/applications/devel#PROXY
-          GLOBAL_AGENT_HTTP_PROXY: vault:secret/data/applications/devel#PROXY
-          GLOBAL_AGENT_HTTPS_PROXY: vault:secret/data/applications/devel#PROXY
-          no_proxy: "vault:secret/data/applications/devel#NO_PROXY"
-          GLOBAL_AGENT_NO_PROXY	: "vault:secret/data/applications/devel#NO_PROXY"
+          http_proxy: http://proxy.service:3128
+          https_proxy: http://proxy.service:3128
+          GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
+          GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
+          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0
+          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
           LAUNCHDARKLY_SDK_KEY: "vault:secret/data/applications/devel#LAUNCHDARKLY_SDK_KEY"
 
 configmaps:

--- a/helm/values/branches.yaml
+++ b/helm/values/branches.yaml
@@ -182,7 +182,7 @@ deployments:
             name: hyperion-api
         image: "gcr.io/voice-dev-infra-services/voice/voice-eos-hyperion:{{ .Values.release.tag }}"
         imagePullPolicy: Always
-        command: ["bash", "run.sh","voice-api"]
+        command: ["bash", "scripts/get-secrets.sh","voice-api"]
         lifecycle:
           preStop:
             exec:
@@ -352,7 +352,7 @@ configmaps:
           pm2_scaling: 1
           node_max_old_space_size: 1024
           chain_name: voice
-          server_addr: ${POD_IP}
+          server_addr: $(POD_IP)
           server_port: 7000
           server_name: "{{ .Values.config.serverName }}"
           provider_name: " {{ .Values.config.provider_name }}"

--- a/helm/values/dev.yaml
+++ b/helm/values/dev.yaml
@@ -156,8 +156,8 @@ deployments:
           https_proxy: http://proxy.service:3128
           GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
           GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
-          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0
-          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
+          no_proxy: ".svc.cluster.local,.service,.internal,.vops.int,.googleapis.com,.gcr.io,.gstatic.com,gcr.io,.gcp.cloud.es.io,accounts.google.com,packages.cloud.google.com,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
+          GLOBAL_AGENT_NO_PROXY	: ".svc.cluster.local,.service,.internal,.vops.int,.googleapis.com,.gcr.io,.gstatic.com,gcr.io,.gcp.cloud.es.io,accounts.google.com,packages.cloud.google.com,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
         resources:
           requests:
             cpu: "1500m"
@@ -222,8 +222,8 @@ deployments:
           https_proxy: http://proxy.service:3128
           GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
           GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
-          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0
-          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
+          no_proxy: ".svc.cluster.local,.service,.internal,.vops.int,.googleapis.com,.gcr.io,.gstatic.com,gcr.io,.gcp.cloud.es.io,accounts.google.com,packages.cloud.google.com,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
+          GLOBAL_AGENT_NO_PROXY	: ".svc.cluster.local,.service,.internal,.vops.int,.googleapis.com,.gcr.io,.gstatic.com,gcr.io,.gcp.cloud.es.io,accounts.google.com,packages.cloud.google.com,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
           # LaunchDarkly Config
           LAUNCHDARKLY_SDK_KEY: "vault:secret/data/applications/devel#LAUNCHDARKLY_SDK_KEY"
         lifecycle:

--- a/helm/values/dev.yaml
+++ b/helm/values/dev.yaml
@@ -152,12 +152,12 @@ deployments:
           ELASTIC_PASS: "{{ .Values.config.elastic_pass }}"
           ELASTIC_HOST: "{{ .Values.config.elastic_host }}"
           SERVER_NAME: "{{ .Values.config.server_name }}"
-          http_proxy: vault:secret/data/applications/devel#PROXY
-          https_proxy: vault:secret/data/applications/devel#PROXY
-          GLOBAL_AGENT_HTTP_PROXY: vault:secret/data/applications/devel#PROXY
-          GLOBAL_AGENT_HTTPS_PROXY: vault:secret/data/applications/devel#PROXY
-          no_proxy: "vault:secret/data/applications/devel#NO_PROXY"
-          GLOBAL_AGENT_NO_PROXY	: "vault:secret/data/applications/devel#NO_PROXY"
+          http_proxy: http://proxy.service:3128
+          https_proxy: http://proxy.service:3128
+          GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
+          GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
+          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0
+          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
         resources:
           requests:
             cpu: "1500m"
@@ -218,12 +218,12 @@ deployments:
           ELASTIC_PASS: "{{ .Values.config.elastic_pass }}"
           ELASTIC_HOST: "{{ .Values.config.elastic_host }}"
           SERVER_NAME: "{{ .Values.config.server_name }}"
-          http_proxy: vault:secret/data/applications/devel#PROXY
-          https_proxy: vault:secret/data/applications/devel#PROXY
-          GLOBAL_AGENT_HTTP_PROXY: vault:secret/data/applications/devel#PROXY
-          GLOBAL_AGENT_HTTPS_PROXY: vault:secret/data/applications/devel#PROXY
-          no_proxy: "vault:secret/data/applications/devel#NO_PROXY"
-          GLOBAL_AGENT_NO_PROXY	: "vault:secret/data/applications/devel#NO_PROXY"
+          http_proxy: http://proxy.service:3128
+          https_proxy: http://proxy.service:3128
+          GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
+          GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
+          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0
+          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
           # LaunchDarkly Config
           LAUNCHDARKLY_SDK_KEY: "vault:secret/data/applications/devel#LAUNCHDARKLY_SDK_KEY"
         lifecycle:

--- a/helm/values/dev.yaml
+++ b/helm/values/dev.yaml
@@ -9,7 +9,7 @@ config:
   es_replicas: 1
   abi_scan: false
   elastic_host:  vault:secret/data/devops/elasticsearch#ELASTIC_HOST
-  elastic_user: elastic
+  elastic_user: "test"
   elastic_pass: vault:secret/data/devops/elasticsearch#ELASTIC_PASSWORD
 
 services:
@@ -154,10 +154,10 @@ deployments:
           GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
           no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io
           GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io"
-          elastic_user: {{ .Values.config.elastic_user}}
-          elastic_pass: {{ .Values.config.elastic_pass}}
-          elastic_host: {{ .Values.config.elastic_host}}
-          server_name: {{ .Values.config.server_name}}
+          elastic_user: "{{ .Values.config.elastic_user}}"
+          elastic_pass: "{{ .Values.config.elastic_pass}}"
+          elastic_host: "{{ .Values.config.elastic_host}}"
+          server_name: "{{ .Values.config.server_name}}"
         resources:
           requests:
             cpu: "1500m"
@@ -167,7 +167,7 @@ deployments:
             mountPath: /tmp/connections.json
             subPath: connections.json
           - name: "{{ if .Values.config.abi_scan }}eos-hyperion-config-abi{{ else }}eos-hyperion-config{{ end }}"
-            mountPath: hyperion-history-api/chains/voice.config.json
+            mountPath: /tmp/voice.config.json/chains/voice.config.json
             subPath: voice.config.json
 
   voice-eos-hyperion-api:
@@ -220,10 +220,10 @@ deployments:
           GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
           no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io
           GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io"
-          elastic_user: {{ .Values.config.elastic_user}}
-          elastic_pass: {{ .Values.config.elastic_pass}}
-          elastic_host: {{ .Values.config.elastic_host}}
-          server_name: {{ .Values.config.server_name}}
+          elastic_user: "{{ .Values.config.elastic_user}}"
+          elastic_pass: "{{ .Values.config.elastic_pass}}"
+          elastic_host: "{{ .Values.config.elastic_host}}"
+          server_name: "{{ .Values.config.server_name}}"
           # LaunchDarkly Config
           LAUNCHDARKLY_SDK_KEY: "vault:secret/data/applications/devel#LAUNCHDARKLY_SDK_KEY"
         lifecycle:
@@ -243,7 +243,7 @@ deployments:
             subPath: connections.json
             readOnly: false
           - name: "{{ if .Values.config.abi_scan }}eos-hyperion-config-abi{{ else }}eos-hyperion-config{{ end }}"
-            mountPath: /hyperion-history-api/chains/voice.config.json
+            mountPath: /tmp/voice.config.json/chains/voice.config.json
             subPath: voice.config.json
             readOnly: false
 hpas:

--- a/helm/values/dev.yaml
+++ b/helm/values/dev.yaml
@@ -152,6 +152,12 @@ deployments:
           ELASTIC_PASS: "{{ .Values.config.elastic_pass }}"
           ELASTIC_HOST: "{{ .Values.config.elastic_host }}"
           SERVER_NAME: "{{ .Values.config.server_name }}"
+          http_proxy: vault:secret/data/applications/devel#PROXY
+          https_proxy: vault:secret/data/applications/devel#PROXY
+          GLOBAL_AGENT_HTTP_PROXY: vault:secret/data/applications/devel#PROXY
+          GLOBAL_AGENT_HTTPS_PROXY: vault:secret/data/applications/devel#PROXY
+          no_proxy: "vault:secret/data/applications/devel#NO_PROXY"
+          GLOBAL_AGENT_NO_PROXY	: "vault:secret/data/applications/devel#NO_PROXY"
         resources:
           requests:
             cpu: "1500m"
@@ -212,6 +218,12 @@ deployments:
           ELASTIC_PASS: "{{ .Values.config.elastic_pass }}"
           ELASTIC_HOST: "{{ .Values.config.elastic_host }}"
           SERVER_NAME: "{{ .Values.config.server_name }}"
+          http_proxy: vault:secret/data/applications/devel#PROXY
+          https_proxy: vault:secret/data/applications/devel#PROXY
+          GLOBAL_AGENT_HTTP_PROXY: vault:secret/data/applications/devel#PROXY
+          GLOBAL_AGENT_HTTPS_PROXY: vault:secret/data/applications/devel#PROXY
+          no_proxy: "vault:secret/data/applications/devel#NO_PROXY"
+          GLOBAL_AGENT_NO_PROXY	: "vault:secret/data/applications/devel#NO_PROXY"
           # LaunchDarkly Config
           LAUNCHDARKLY_SDK_KEY: "vault:secret/data/applications/devel#LAUNCHDARKLY_SDK_KEY"
         lifecycle:

--- a/helm/values/prod.yaml
+++ b/helm/values/prod.yaml
@@ -8,9 +8,9 @@ config:
   chain_logo_url: "https://storage.googleapis.com/voice_logo/logo.ico"
   es_replicas: 1
   abi_scan: false
-  elastic_host:  vault:secret/data/devops/elasticsearch#ELASTIC_HOST
+  elastic_host:  vault:secret/data/devops/elastic#ELASTIC_HOST
   elastic_user: elastic
-  elastic_pass:  vault:secret/data/devops/elasticsearch#ELASTIC_HOST
+  elastic_pass:  vault:secret/data/devops/elastic#ELASTIC_HOST
 
 services:
   voice-eos-hyperion:

--- a/helm/values/prod.yaml
+++ b/helm/values/prod.yaml
@@ -156,8 +156,8 @@ deployments:
           https_proxy: http://proxy.service:3128
           GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
           GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
-          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0
-          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
+          no_proxy: ".svc.cluster.local,.service,.internal,.vops.int,.googleapis.com,.gcr.io,.gstatic.com,gcr.io,.gcp.cloud.es.io,accounts.google.com,packages.cloud.google.com,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
+          GLOBAL_AGENT_NO_PROXY	: ".svc.cluster.local,.service,.internal,.vops.int,.googleapis.com,.gcr.io,.gstatic.com,gcr.io,.gcp.cloud.es.io,accounts.google.com,packages.cloud.google.com,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
         resources:
           requests:
             cpu: "1500m"
@@ -228,8 +228,8 @@ deployments:
           https_proxy: http://proxy.service:3128
           GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
           GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
-          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0
-          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
+          no_proxy: ".svc.cluster.local,.service,.internal,.vops.int,.googleapis.com,.gcr.io,.gstatic.com,gcr.io,.gcp.cloud.es.io,accounts.google.com,packages.cloud.google.com,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
+          GLOBAL_AGENT_NO_PROXY	: ".svc.cluster.local,.service,.internal,.vops.int,.googleapis.com,.gcr.io,.gstatic.com,gcr.io,.gcp.cloud.es.io,accounts.google.com,packages.cloud.google.com,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
           # LaunchDarkly Config
           LAUNCHDARKLY_SDK_KEY: "vault:secret/data/applications/prod#LAUNCHDARKLY_SDK_KEY"
         lifecycle:

--- a/helm/values/prod.yaml
+++ b/helm/values/prod.yaml
@@ -8,9 +8,9 @@ config:
   chain_logo_url: "https://storage.googleapis.com/voice_logo/logo.ico"
   es_replicas: 1
   abi_scan: false
-  elastic_host: vault:secret/data/devops/elasticsearch#ELASTIC_HOST
+  elastic_host: elastic.service
   elastic_user: elastic
-  elastic_pass: vault:secret/data/devops/elasticsearch#ELASTIC_PASSWORD
+  elastic_pass: '""'
 
 services:
   voice-eos-hyperion:

--- a/helm/values/prod.yaml
+++ b/helm/values/prod.yaml
@@ -152,12 +152,12 @@ deployments:
           ELASTIC_PASS: "{{ .Values.config.elastic_pass }}"
           ELASTIC_HOST: "{{ .Values.config.elastic_host }}"
           SERVER_NAME: "{{ .Values.config.server_name }}"
-          http_proxy: vault:secret/data/applications/devel#PROXY
-          https_proxy: vault:secret/data/applications/devel#PROXY
-          GLOBAL_AGENT_HTTP_PROXY: vault:secret/data/applications/devel#PROXY
-          GLOBAL_AGENT_HTTPS_PROXY: vault:secret/data/applications/devel#PROXY
-          no_proxy: "vault:secret/data/applications/devel#NO_PROXY"
-          GLOBAL_AGENT_NO_PROXY	: "vault:secret/data/applications/devel#NO_PROXY"
+          http_proxy: http://proxy.service:3128
+          https_proxy: http://proxy.service:3128
+          GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
+          GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
+          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0
+          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
         resources:
           requests:
             cpu: "1500m"
@@ -224,12 +224,12 @@ deployments:
           ELASTIC_PASS: "{{ .Values.config.elastic_pass }}"
           ELASTIC_HOST: "{{ .Values.config.elastic_host }}"
           SERVER_NAME: "{{ .Values.config.server_name }}"
-          http_proxy: vault:secret/data/applications/devel#PROXY
-          https_proxy: vault:secret/data/applications/devel#PROXY
-          GLOBAL_AGENT_HTTP_PROXY: vault:secret/data/applications/devel#PROXY
-          GLOBAL_AGENT_HTTPS_PROXY: vault:secret/data/applications/devel#PROXY
-          no_proxy: "vault:secret/data/applications/devel#NO_PROXY"
-          GLOBAL_AGENT_NO_PROXY	: "vault:secret/data/applications/devel#NO_PROXY"
+          http_proxy: http://proxy.service:3128
+          https_proxy: http://proxy.service:3128
+          GLOBAL_AGENT_HTTP_PROXY: http://proxy.service:3128
+          GLOBAL_AGENT_HTTPS_PROXY: http://proxy.service:3128
+          no_proxy: .svc.cluster.local,.service,.internal,.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0
+          GLOBAL_AGENT_NO_PROXY	: "*.svc.cluster.local,*.service,*.internal,*.vops.int,metadata.google.internal,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,.psc.us-west1.gcp.cloud.es.io,0.0.0.0"
           # LaunchDarkly Config
           LAUNCHDARKLY_SDK_KEY: "vault:secret/data/applications/prod#LAUNCHDARKLY_SDK_KEY"
         lifecycle:

--- a/helm/values/prod.yaml
+++ b/helm/values/prod.yaml
@@ -152,6 +152,12 @@ deployments:
           ELASTIC_PASS: "{{ .Values.config.elastic_pass }}"
           ELASTIC_HOST: "{{ .Values.config.elastic_host }}"
           SERVER_NAME: "{{ .Values.config.server_name }}"
+          http_proxy: vault:secret/data/applications/devel#PROXY
+          https_proxy: vault:secret/data/applications/devel#PROXY
+          GLOBAL_AGENT_HTTP_PROXY: vault:secret/data/applications/devel#PROXY
+          GLOBAL_AGENT_HTTPS_PROXY: vault:secret/data/applications/devel#PROXY
+          no_proxy: "vault:secret/data/applications/devel#NO_PROXY"
+          GLOBAL_AGENT_NO_PROXY	: "vault:secret/data/applications/devel#NO_PROXY"
         resources:
           requests:
             cpu: "1500m"
@@ -218,6 +224,12 @@ deployments:
           ELASTIC_PASS: "{{ .Values.config.elastic_pass }}"
           ELASTIC_HOST: "{{ .Values.config.elastic_host }}"
           SERVER_NAME: "{{ .Values.config.server_name }}"
+          http_proxy: vault:secret/data/applications/devel#PROXY
+          https_proxy: vault:secret/data/applications/devel#PROXY
+          GLOBAL_AGENT_HTTP_PROXY: vault:secret/data/applications/devel#PROXY
+          GLOBAL_AGENT_HTTPS_PROXY: vault:secret/data/applications/devel#PROXY
+          no_proxy: "vault:secret/data/applications/devel#NO_PROXY"
+          GLOBAL_AGENT_NO_PROXY	: "vault:secret/data/applications/devel#NO_PROXY"
           # LaunchDarkly Config
           LAUNCHDARKLY_SDK_KEY: "vault:secret/data/applications/prod#LAUNCHDARKLY_SDK_KEY"
         lifecycle:

--- a/helm/values/prod.yaml
+++ b/helm/values/prod.yaml
@@ -8,9 +8,9 @@ config:
   chain_logo_url: "https://storage.googleapis.com/voice_logo/logo.ico"
   es_replicas: 1
   abi_scan: false
-  elastic_host: elastic.service
+  elastic_host:  vault:secret/data/devops/elasticsearch#ELASTIC_HOST
   elastic_user: elastic
-  elastic_pass: '""'
+  elastic_pass:  vault:secret/data/devops/elasticsearch#ELASTIC_HOST
 
 services:
   voice-eos-hyperion:

--- a/helm/values/prod.yaml
+++ b/helm/values/prod.yaml
@@ -8,6 +8,10 @@ config:
   chain_logo_url: "https://storage.googleapis.com/voice_logo/logo.ico"
   es_replicas: 1
   abi_scan: false
+  elastic_host:  vault:secret/data/devops/elasticsearch#ELASTIC_HOST
+  elastic_user: elastic
+  elastic_pass: vault:secret/data/devops/elasticsearch#ELASTIC_PASSWORD
+
 services:
   voice-eos-hyperion:
     customLabels:
@@ -157,7 +161,7 @@ deployments:
             memory: "1024Mi"
         volumeMounts:
           - name: eos-hyperion-connections
-            mountPath: /hyperion-history-api/connections.json
+            mountPath: /tmp/connections.json
             subPath: connections.json
           - name: "{{ if .Values.config.abi_scan }}eos-hyperion-config-abi{{ else }}eos-hyperion-config{{ end }}"
             mountPath: hyperion-history-api/chains/voice.config.json
@@ -220,8 +224,6 @@ deployments:
           elastic_pass: {{ .Values.config.elastic_pass}}
           elastic_host: {{ .Values.config.elastic_host}}
           server_name: {{ .Values.config.server_name}}
-          # LaunchDarkly Config
-          LAUNCHDARKLY_SDK_KEY: "vault:secret/data/applications/prod#LAUNCHDARKLY_SDK_KEY"
         lifecycle:
           preStop:
             exec:
@@ -235,13 +237,11 @@ deployments:
             memory: "256Mi"
         volumeMounts:
           - name: eos-hyperion-connections
-            mountPath: hyperion-history-api/connections.json
+            mountPath: /tmp/connections.json
             subPath: connections.json
-            readOnly: false
           - name: "{{ if .Values.config.abi_scan }}eos-hyperion-config-abi{{ else }}eos-hyperion-config{{ end }}"
             mountPath: hyperion-history-api/chains/voice.config.json
             subPath: voice.config.json
-            readOnly: false
 hpas:
   voice-eos-hyperion-api:
     minReplicas: 1

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-export no_proxy="${no_proxy},0.0.0.0"
-export GLOBAL_AGENT_NO_PROXY="${GLOBAL_AGENT_NO_PROXY},0.0.0.0"
 if [ $# -eq 0 ]; then
   echo 'Please inform the app name. ex: "./run.sh indexer"'
   exit 1

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+jq --arg  pod_ip $POD_IP \
+    '.api.server_addr = $POD_IP'  /hyperion-history-api/chains/voice.config.json > /hyperion-history-api/chains/tmp.json && \
+    mv /hyperion-history-api/chains/tmp.json /hyperion-history-api/chains/voice.config.json
+
 if [ $# -eq 0 ]; then
   echo 'Please inform the app name. ex: "./run.sh indexer"'
   exit 1

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,4 @@
 #!/usr/bin/env bash
-
-jq --arg  pod_ip $POD_IP \
-    '.api.server_addr = $POD_IP'  /hyperion-history-api/chains/voice.config.json > /hyperion-history-api/chains/tmp.json && \
-    mv /hyperion-history-api/chains/tmp.json /hyperion-history-api/chains/voice.config.json
-
 if [ $# -eq 0 ]; then
   echo 'Please inform the app name. ex: "./run.sh indexer"'
   exit 1

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+export no_proxy="${no_proxy},0.0.0.0"
+export GLOBAL_AGENT_NO_PROXY="${GLOBAL_AGENT_NO_PROXY},0.0.0.0"
 if [ $# -eq 0 ]; then
   echo 'Please inform the app name. ex: "./run.sh indexer"'
   exit 1

--- a/scripts/get-secrets.sh
+++ b/scripts/get-secrets.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 set -eu
-export NO_PROXY="$NO_PROXY:$POD_IP"
-
 jq -n --arg  elastic_user $ELASTIC_USER  --arg  elastic_pass $ELASTIC_PASS --arg elastic_host $ELASTIC_HOST \
     '.elasticsearch.user = $elastic_user | .elasticsearch.pass =  $elastic_pass | .elasticsearch.host = $elastic_host | .elasticsearch.ingest_nodes = [$elastic_host] '  \
     /tmp/connections.json > /hyperion-history-api/connections.json
 
-jq -n --arg server_name $SERVER_NAME --arg pod_ip "$POD_IP" \
+jq -n --arg server_name $SERVER_NAME \
     '.api.server_name = $server_name | .api.server_addr = $pod_ip'  /tmp/voice.config.json > /hyperion-history-api/chains/voice.config.json
 ./run.sh $@

--- a/scripts/get-secrets.sh
+++ b/scripts/get-secrets.sh
@@ -7,6 +7,6 @@ jq --arg elastic_user $elastic_user --arg  elastic_pass $elastic_pass --arg elas
     /tmp/connections.json > /hyperion-history-api/connections.json
 
 jq --arg  server_name $server_name \
-    '.api.server_name = $server_name'  /temp/voice.config.json> chains/example.config.json
+    '.api.server_name = $server_name'  /temp/voice.config.json> /hyperion-history-api/chains/voice.config.json
 
 ./run.sh $@

--- a/scripts/get-secrets.sh
+++ b/scripts/get-secrets.sh
@@ -6,7 +6,6 @@ jq --arg elastic_user $ELASTIC_USER --arg  elastic_pass $ELASTIC_PASS --arg elas
     '.elasticsearch.user = $elastic_user | .elasticsearch.pass =  $elastic_pass | .elasticsearch.host = $elastic_host | .elasticsearch.ingest_nodes = [$elastic_host] '  \
     /tmp/connections.json > /hyperion-history-api/connections.json
 
-jq --arg  server_name $SERVER_NAME \
-    '.api.server_name = $server_name'  /tmp/voice.config.json> /hyperion-history-api/chains/voice.config.json
-
+jq --arg  server_name $SERVER_NAME  --arg  pod_ip $POD_IP \
+    '.api.server_name = $server_name |.api.server_addr = $POD_IP'  /tmp/voice.config.json> /hyperion-history-api/chains/voice.config.json
 ./run.sh $@

--- a/scripts/get-secrets.sh
+++ b/scripts/get-secrets.sh
@@ -5,5 +5,5 @@ jq -n --arg  elastic_user $ELASTIC_USER  --arg  elastic_pass $ELASTIC_PASS --arg
     /tmp/connections.json > /hyperion-history-api/connections.json
 
 jq -n --arg server_name $SERVER_NAME \
-    '.api.server_name = $server_name | .api.server_addr = $pod_ip'  /tmp/voice.config.json > /hyperion-history-api/chains/voice.config.json
+    '.api.server_name = $server_name'  /tmp/voice.config.json > /hyperion-history-api/chains/voice.config.json
 ./run.sh $@

--- a/scripts/get-secrets.sh
+++ b/scripts/get-secrets.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -eu
+export NO_PROXY="$NO_PROXY:$POD_IP"
 
 jq -n --arg  elastic_user $ELASTIC_USER  --arg  elastic_pass $ELASTIC_PASS --arg elastic_host $ELASTIC_HOST \
     '.elasticsearch.user = $elastic_user | .elasticsearch.pass =  $elastic_pass | .elasticsearch.host = $elastic_host | .elasticsearch.ingest_nodes = [$elastic_host] '  \
     /tmp/connections.json > /hyperion-history-api/connections.json
 
-jq --arg  server_name $SERVER_NAME  --arg  pod_ip $POD_IP \
-    '.api.server_name = $server_name |.api.server_addr = $pod_ip'  /tmp/voice.config.json> /hyperion-history-api/chains/voice.config.json
+jq -n --arg server_name $SERVER_NAME --arg pod_ip "$POD_IP" \
+    '.api.server_name = $server_name | .api.server_addr = $pod_ip'  /tmp/voice.config.json > /hyperion-history-api/chains/voice.config.json
 ./run.sh $@

--- a/scripts/get-secrets.sh
+++ b/scripts/get-secrets.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-
 set -eu
 
-jq --arg elastic_user $ELASTIC_USER --arg  elastic_pass $ELASTIC_PASS --arg elastic_host $ELASTIC_HOST \
+jq -n --arg  elastic_user $ELASTIC_USER --arg  elastic_pass $ELASTIC_PASS --arg elastic_host $ELASTIC_HOST \
     '.elasticsearch.user = $elastic_user | .elasticsearch.pass =  $elastic_pass | .elasticsearch.host = $elastic_host | .elasticsearch.ingest_nodes = [$elastic_host] '  \
     /tmp/connections.json > /hyperion-history-api/connections.json
 

--- a/scripts/get-secrets.sh
+++ b/scripts/get-secrets.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -eu
 
-jq -n --arg  elastic_user $ELASTIC_USER --arg  elastic_pass $ELASTIC_PASS --arg elastic_host $ELASTIC_HOST \
+jq -n --arg  elastic_user $ELASTIC_USER  --arg  elastic_pass $ELASTIC_PASS --arg elastic_host $ELASTIC_HOST \
     '.elasticsearch.user = $elastic_user | .elasticsearch.pass =  $elastic_pass | .elasticsearch.host = $elastic_host | .elasticsearch.ingest_nodes = [$elastic_host] '  \
     /tmp/connections.json > /hyperion-history-api/connections.json
 
 jq --arg  server_name $SERVER_NAME  --arg  pod_ip $POD_IP \
-    '.api.server_name = $server_name |.api.server_addr = $POD_IP'  /tmp/voice.config.json> /hyperion-history-api/chains/voice.config.json
+    '.api.server_name = $server_name |.api.server_addr = $pod_ip'  /tmp/voice.config.json> /hyperion-history-api/chains/voice.config.json
 ./run.sh $@


### PR DESCRIPTION
in this PR we added the proxy environment variables for the hyperion-history-api as they are different form the the rest of the repos.
this will provide the repo to connect to the internet through the proxy to the whitelisted domains. and the no_proxy will prevent some of the request to be routed to the proxy ( internal traffic ) 
see example: https://github.com/voice-social/hyperion-history-api/blob/test-proxy/helm/values/dev.yaml#L155
I have also add the ability to release the app to production in .buildkite/prod.yaml