### PR TITLE
THE-543: Disable all V1 api's that the frontend doesn't call

### DIFF
--- a/api/routes.ts
+++ b/api/routes.ts
@@ -58,13 +58,9 @@ export function registerRoutes(server: FastifyInstance, featureFlagClient?: Feat
     addRoute(server, 'v2-stats', '/v2/stats');
 
     // legacy routes
-    // addRoute(server, 'v1-history', '/v1/history');
     addRoute(server, 'v1-trace', '/v1/trace_api', featureFlagClient);
 
     addSharedSchemas(server);
-
-    // chain api redirects
-    // addRoute(server, 'v1-chain', '/v1/chain');
 
 	  // other v1 requests
     server.route({
@@ -87,26 +83,6 @@ export function registerRoutes(server: FastifyInstance, featureFlagClient?: Feat
             }
         }
     });
-
-  //   // /v1/node/get_supported_apis
-  //   server.route({
-  //       url: '/v1/node/get_supported_apis',
-  //       method: ["GET"],
-  //       schema: {
-  //           summary: "Get list of supported APIs",
-  //           tags: ["node"]
-  //       },
-  //       handler: async (request: FastifyRequest, reply: FastifyReply) => {
-  //           const data = await got.get(`${server.chain_api}/v1/node/get_supported_apis`).json() as any;
-  //           if (data.apis && data.apis.length > 0) {
-  //               const apiSet = new Set(server.routeSet);
-  //               data.apis.forEach((a) => apiSet.add(a));
-  //               reply.send({apis: [...apiSet]});
-  //           } else {
-  //               reply.send({apis: [...server.routeSet], error: 'nodeos did not send any data'});
-  //           }
-  //       }
-  //   });
 
     server.addHook('onError', (request: FastifyRequest, reply: FastifyReply, error: FastifyError, done) => {
         console.log(`[${request.headers['x-real-ip'] || request.ip}] ${request.method} ${request.url} failed >> ${error.message}`);

--- a/api/routes.ts
+++ b/api/routes.ts
@@ -58,49 +58,49 @@ export function registerRoutes(server: FastifyInstance, featureFlagClient?: Feat
     addRoute(server, 'v2-stats', '/v2/stats');
 
     // legacy routes
-    addRoute(server, 'v1-history', '/v1/history');
-    addRoute(server, 'v1-trace', '/v1/trace_api', featureFlagClient);
+    // addRoute(server, 'v1-history', '/v1/history');
+    // addRoute(server, 'v1-trace', '/v1/trace_api', featureFlagClient);
 
     addSharedSchemas(server);
 
     // chain api redirects
-    addRoute(server, 'v1-chain', '/v1/chain');
+  //   addRoute(server, 'v1-chain', '/v1/chain');
 
-	// other v1 requests
-    server.route({
-        url: '/v1/chain/*',
-        method: ["GET", "POST"],
-        schema: {
-            summary: "Wildcard chain api handler",
-            tags: ["chain"]
-        },
-        handler: async (request: FastifyRequest, reply: FastifyReply) => {
+	// // other v1 requests
+  //   server.route({
+  //       url: '/v1/chain/*',
+  //       method: ["GET", "POST"],
+  //       schema: {
+  //           summary: "Wildcard chain api handler",
+  //           tags: ["chain"]
+  //       },
+  //       handler: async (request: FastifyRequest, reply: FastifyReply) => {
 
-            console.log(request.url);
+  //           console.log(request.url);
 
-            await handleChainApiRedirect(request, reply, server);
-        }
-    });
+  //           await handleChainApiRedirect(request, reply, server);
+  //       }
+  //   });
 
-    // /v1/node/get_supported_apis
-    server.route({
-        url: '/v1/node/get_supported_apis',
-        method: ["GET"],
-        schema: {
-            summary: "Get list of supported APIs",
-            tags: ["node"]
-        },
-        handler: async (request: FastifyRequest, reply: FastifyReply) => {
-            const data = await got.get(`${server.chain_api}/v1/node/get_supported_apis`).json() as any;
-            if (data.apis && data.apis.length > 0) {
-                const apiSet = new Set(server.routeSet);
-                data.apis.forEach((a) => apiSet.add(a));
-                reply.send({apis: [...apiSet]});
-            } else {
-                reply.send({apis: [...server.routeSet], error: 'nodeos did not send any data'});
-            }
-        }
-    });
+  //   // /v1/node/get_supported_apis
+  //   server.route({
+  //       url: '/v1/node/get_supported_apis',
+  //       method: ["GET"],
+  //       schema: {
+  //           summary: "Get list of supported APIs",
+  //           tags: ["node"]
+  //       },
+  //       handler: async (request: FastifyRequest, reply: FastifyReply) => {
+  //           const data = await got.get(`${server.chain_api}/v1/node/get_supported_apis`).json() as any;
+  //           if (data.apis && data.apis.length > 0) {
+  //               const apiSet = new Set(server.routeSet);
+  //               data.apis.forEach((a) => apiSet.add(a));
+  //               reply.send({apis: [...apiSet]});
+  //           } else {
+  //               reply.send({apis: [...server.routeSet], error: 'nodeos did not send any data'});
+  //           }
+  //       }
+  //   });
 
     server.addHook('onError', (request: FastifyRequest, reply: FastifyReply, error: FastifyError, done) => {
         console.log(`[${request.headers['x-real-ip'] || request.ip}] ${request.method} ${request.url} failed >> ${error.message}`);

--- a/api/routes.ts
+++ b/api/routes.ts
@@ -59,28 +59,34 @@ export function registerRoutes(server: FastifyInstance, featureFlagClient?: Feat
 
     // legacy routes
     // addRoute(server, 'v1-history', '/v1/history');
-    // addRoute(server, 'v1-trace', '/v1/trace_api', featureFlagClient);
+    addRoute(server, 'v1-trace', '/v1/trace_api', featureFlagClient);
 
     addSharedSchemas(server);
 
     // chain api redirects
-  //   addRoute(server, 'v1-chain', '/v1/chain');
+    // addRoute(server, 'v1-chain', '/v1/chain');
 
-	// // other v1 requests
-  //   server.route({
-  //       url: '/v1/chain/*',
-  //       method: ["GET", "POST"],
-  //       schema: {
-  //           summary: "Wildcard chain api handler",
-  //           tags: ["chain"]
-  //       },
-  //       handler: async (request: FastifyRequest, reply: FastifyReply) => {
+	  // other v1 requests
+    server.route({
+        url: '/v1/chain/*',
+        method: ["GET", "POST"],
+        schema: {
+            summary: "Wildcard chain api handler",
+            tags: ["chain"]
+        },
+        handler: async (request: FastifyRequest, reply: FastifyReply) => {
 
-  //           console.log(request.url);
+            console.log(request.url);
 
-  //           await handleChainApiRedirect(request, reply, server);
-  //       }
-  //   });
+            // restrict access to only the api endpoints the frontend is using
+            const allowedRoutes = ['/v1/chain/get_info', '/v1/chain/get_table_by_scope']
+            if (!allowedRoutes.includes(request.url)) {
+               await handleChainApiRedirect(request, reply, server);
+            } else {
+                reply.code(404).send({ error: 'Not found' });
+            }
+        }
+    });
 
   //   // /v1/node/get_supported_apis
   //   server.route({


### PR DESCRIPTION
This filters out all of the v1 api endpoints that are not being used by the frontend so we don't enable users to query our blockchain directly using this.