### PR TITLE
fix the promoted image name

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -36,7 +36,7 @@ steps:
 # promote image
   - label: ":arrow_up: Trigger gcrane promote"
     command:
-      - "buildkite-agent pipeline upload voice-buildkite-template/gcrane/promote/template.yaml"
+      - "buildkite-agent pipeline upload voice-buildkite-template/gcrane/promote/main-prod/template.yaml"
     env:
       IMAGE_NAME: voice-eos-hyperion
     agents: *default-agents


### PR DESCRIPTION
Jira: URL [DSO-399](https://voice-llc.atlassian.net/browse/DSO-399)
had to fix the template as this service is deployed to the voice-main-prod cluster not the voice-ops-prod cluster so it has to use the path gcr.io/voice-prod-infra-services/voice instead of gcr.io/voice-ops-prod/voice. 